### PR TITLE
Vendor API for submission status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.4
+FROM semtech/mu-javascript-template:feature-node-16-support
 LABEL maintainer=info@redpencil

--- a/SubmissionRegistrationContext.js
+++ b/SubmissionRegistrationContext.js
@@ -1,0 +1,56 @@
+export const SubmissionRegistrationContext = {
+  prov: 'http://www.w3.org/ns/prov#',
+  dct: 'http://purl.org/dc/terms/',
+  muAccount: 'http://mu.semte.ch/vocabularies/account/',
+  dgftOauth: 'http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/',
+  dgftSec: 'http://lblod.data.gift/vocabularies/security/',
+  meb: 'http://rdf.myexperiment.org/ontologies/base/',
+  pav: 'http://purl.org/pav/',
+  adms: 'http://www.w3.org/ns/adms#',
+  wotSec: 'https://www.w3.org/2019/wot/security#',
+  organization: {
+    '@id': 'pav:createdBy',
+    '@type': '@id',
+  },
+  href: {
+    '@type': '@id',
+    '@id': 'prov:atLocation',
+  },
+  submittedResource: {
+    '@type': '@id',
+    '@id': 'dct:subject',
+  },
+  key: 'muAccount:key',
+  publisher: 'pav:providedBy',
+  uri: {
+    '@type': '@id',
+    '@id': '@id',
+  },
+  status: {
+    '@type': '@id',
+    '@id': 'adms:status',
+  },
+  authentication: 'dgftSec:targetAuthenticationConfiguration',
+  configuration: 'dgftSec:securityConfiguration',
+  credentials: 'dgftSec:secrets',
+  acceptedBy: 'dgftSec:acceptedBy',
+  oauth2: {
+    '@type': '@id',
+    '@id': 'wotSec:OAuth2SecurityScheme',
+  },
+  basic: {
+    '@type': '@id',
+    '@id': 'wotSec:BasicSecurityScheme',
+  },
+  flow: 'wotSec:flow',
+  token: 'wotSec:token',
+  scheme: {
+    '@id': '@type',
+    '@type': '@vocab',
+  },
+  resource: 'dgftOauth:resource',
+  clientId: 'dgftOauth:clientId',
+  clientSecret: 'dgftOauth:clientSecret',
+  username: 'meb:username',
+  password: 'muAccount:password',
+};

--- a/SubmissionRegistrationContext.js
+++ b/SubmissionRegistrationContext.js
@@ -53,4 +53,8 @@ export const SubmissionRegistrationContext = {
   clientSecret: 'dgftOauth:clientSecret',
   username: 'meb:username',
   password: 'muAccount:password',
+  submission: {
+    '@type': '@id',
+    '@id': 'dct:subject',
+  },
 };

--- a/app.js
+++ b/app.js
@@ -248,29 +248,15 @@ async function ensureAuthorisation(store) {
     );
 }
 
-async function jsonLdToStore(jsonLdObect) {
-  const requestNQuads = await jsonld.default.toRDF(jsonLdObect, {
-    format: 'application/n-quads',
-  });
-  const parser = new N3.Parser({ format: 'application/n-quads' });
-  const requestRdfjsTriples = parser.parse(requestNQuads);
+async function jsonLdToStore(jsonLdObject) {
+  const requestQuads = await jsonld.default.toRDF(jsonLdObject, {});
   const store = new N3.Store();
-  store.addQuads(requestRdfjsTriples);
+  store.addQuads(requestQuads);
   return store;
 }
 
 async function storeToJsonLd(store, context, frame) {
-  const writer = new N3.Writer({ format: 'application/n-quads' });
-  store.forEach((quad) => writer.addQuad(quad));
-  const ttl = await new Promise((resolve, reject) => {
-    writer.end((error, result) => {
-      if (error) reject(error);
-      else resolve(result);
-    });
-  });
-  const jsonld1 = await jsonld.default.fromRDF(ttl, {
-    format: 'application/n-quads',
-  });
+  const jsonld1 = await jsonld.default.fromRDF([...store], {});
   const framed = await jsonld.default.frame(jsonld1, frame);
   const compacted = await jsonld.default.compact(framed, context);
   return compacted;

--- a/env.js
+++ b/env.js
@@ -25,9 +25,11 @@ export const CREATOR = 'http://lblod.data.gift/services/automatic-submission-ser
 
 export const PREFIX_TABLE = {
   meb:          'http://rdf.myexperiment.org/ontologies/base/',
+  rdf:          'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   xsd:          'http://www.w3.org/2001/XMLSchema#',
   pav:          'http://purl.org/pav/',
   dct:          'http://purl.org/dc/terms/',
+  oslc:         'http://open-services.net/ns/core#',
   melding:      'http://lblod.data.gift/vocabularies/automatische-melding/',
   lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
   adms:         'http://www.w3.org/ns/adms#',

--- a/jobAndTaskManagement.js
+++ b/jobAndTaskManagement.js
@@ -124,16 +124,16 @@ const JobStatusFrame = {
     '@embed': '@always',
   },
 };
-export async function getJobStatusRdfJS(jobUri) {
+export async function getSubmissionStatusRdfJS(submissionUri) {
   const response = await query(`
     ${env.PREFIXES}
     CONSTRUCT {
-      ${sparqlEscapeUri(jobUri)}
+      ?job
         a cogs:Job ;
         adms:status ?jobStatus ;
         prov:generated ?submission ;
         task:error ?error.
-      ?submission
+      ${sparqlEscapeUri(submissionUri)}
         rdf:type meb:Submission ;
         adms:status ?submissionStatus .
       ?error
@@ -141,18 +141,18 @@ export async function getJobStatusRdfJS(jobUri) {
         oslc:message ?message .
     }
     WHERE {
-      ${sparqlEscapeUri(jobUri)}
+      ${sparqlEscapeUri(submissionUri)}
+        rdf:type meb:Submission ;
+        adms:status ?submissionStatus .
+      ?job
         a cogs:Job ;
         dct:creator services:automatic-submission-service ;
         adms:status ?jobStatus ;
         task:cogsOperation cogs:TransformationProcess ;
         task:operation jobo:automaticSubmissionFlow ;
         prov:generated ?submission .
-      ?submission
-        rdf:type meb:Submission ;
-        adms:status ?submissionStatus .
       OPTIONAL {
-        ${sparqlEscapeUri(jobUri)}
+        ?job
           task:error ?error .
         ?error
           a oslc:Error ;

--- a/jsonld-input.js
+++ b/jsonld-input.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { uuid } from 'mu';
 import * as env from './env.js';
+import { SubmissionRegistrationContext } from './SubmissionRegistrationContext.js';
 
 /*
  * This method ensures some basic things on the root node of the request body
@@ -11,8 +12,8 @@ export async function enrichBody(originalBody) {
   if (!originalBody["@type"]) {
     originalBody["@type"] = "meb:Submission";
   }
-  if (!originalBody["@context"]) {
-    originalBody["@context"] = env.AUTOMATIC_SUBMISSION_JSON_LD_CONTEXT_ENDPOINT;
+  if (!originalBody['@context']) {
+    originalBody['@context'] = SubmissionRegistrationContext;
   }
   const id = uuid();
   originalBody["http://mu.semte.ch/vocabularies/core/uuid"] = id;

--- a/jsonld-input.js
+++ b/jsonld-input.js
@@ -2,13 +2,16 @@ import _ from 'lodash';
 import { uuid } from 'mu';
 import * as env from './env.js';
 import { SubmissionRegistrationContext } from './SubmissionRegistrationContext.js';
+const N3 = require('n3');
+const { DataFactory } = N3;
+const { namedNode } = DataFactory;
 
 /*
  * This method ensures some basic things on the root node of the request body
  * e.g the root node should have a URI (@id), context (@context) and a type.
  * it also adds a uuid for internal processing, since it's used for constructing the URI if necessary
  */
-export async function enrichBody(originalBody) {
+export async function enrichBodyForRegister(originalBody) {
   if (!originalBody["@type"]) {
     originalBody["@type"] = "meb:Submission";
   }
@@ -48,7 +51,7 @@ export async function enrichBodyForStatus(body) {
   return body;
 }
 
-export function extractInfoFromTriples(triples) {
+export function extractInfoFromTriplesForRegister(triples) {
   const key = _.get(triples.find(
     (triple) => triple.predicate.value === 'http://mu.semte.ch/vocabularies/account/key'), "object.value");
 
@@ -74,6 +77,26 @@ export function extractInfoFromTriples(triples) {
     submittedResource,
     status,
     authenticationConfiguration
+  };
+}
+
+export function extractAuthentication(store) {
+  const keys = store.getObjects(
+    undefined,
+    namedNode('http://mu.semte.ch/vocabularies/account/key')
+  );
+  const vendors = store.getObjects(
+    undefined,
+    namedNode('http://purl.org/pav/providedBy')
+  );
+  const organisations = store.getObjects(
+    undefined,
+    namedNode('http://purl.org/pav/createdBy')
+  );
+  return {
+    key: keys[0]?.value,
+    vendor: vendors[0]?.value,
+    organisation: organisations[0]?.value,
   };
 }
 

--- a/jsonld-input.js
+++ b/jsonld-input.js
@@ -31,6 +31,23 @@ export async function enrichBody(originalBody) {
   return originalBody;
 }
 
+export async function enrichBodyForStatus(body) {
+  if (!body['@context']) {
+    body['@context'] = SubmissionRegistrationContext;
+  }
+  const requestId = uuid();
+  if (!body['@id'])
+    body['@id'] = `http://data.lblod.info/submission-status-request/${requestId}`;
+  if (!body['@type'])
+    body['@type'] = 'http://data.lblod.info/submission-status-request/Request';
+  if (body.authentication) {
+    body.authentication['@id'] = `http://data.lblod.info/authentications/${uuid()}`;
+    body.authentication.configuration['@id'] = `http://data.lblod.info/configurations/${uuid()}`;
+    body.authentication.credentials['@id'] = `http://data.lblod.info/credentials/${uuid()}`;
+  }
+  return body;
+}
+
 export function extractInfoFromTriples(triples) {
   const key = _.get(triples.find(
     (triple) => triple.predicate.value === 'http://mu.semte.ch/vocabularies/account/key'), "object.value");

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",
     "async-await-mutex-lock": "^1.0.9",
+    "express-rate-limit": "^6.6.0",
     "jsonld": "^8.1.0",
     "lodash": "^4.17.15",
     "n3": "^1.16.2",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Microservice providing an API for external parties to process inzendingen voor toezicht.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",
-    "jsonld": "^1.7.0",
-    "n3": "^1.2.0",
+    "async-await-mutex-lock": "^1.0.9",
+    "jsonld": "^8.1.0",
     "lodash": "^4.17.15",
-    "async-await-mutex-lock": "^1.0.9"
+    "n3": "^1.16.2",
+    "sparqljson-parse": "^2.1.1"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/support.js
+++ b/support.js
@@ -137,7 +137,7 @@ async function storeSubmission(triples, submissionGraph, fileGraph, authenticati
 
     await jobsAndTasks.automaticSubmissionTaskSuccess(submissionGraph, automaticSubmissionTaskUri, jobUri, remoteDataUri);
 
-    return jobUri;
+    return { submissionUri: meldingUri, jobUri };
   } catch (e) {
     console.error(`Something went wrong during the storage of submission ${meldingUri}. This is monitored via task ${automaticSubmissionTaskUri}.`);
     console.error(e.message);


### PR DESCRIPTION
This PR attempts to create a JSON-LD API for the status of a submission with authentication and rate limiting.

**Notable changes:**

* Registering a submission also returns the submission URI (TODO in different PR: update this to JSON-LD like the rest of the response and request formats of this service).
* New API for requesting the status of a submission using JSON-LD with libraries for parsing JSON-LD and processing triples.
* The JSON-LD context is included as a file in this service (I had CORS problems, but also: having the file not locally means you have to download it on every request which is costly.)
* There are some small additions to the JSON-LD context included. (Bottom of the file: 'submission' property.)
* Some packages require a new NodeJS version (16 or higher) to work. Changed that in the Dockerfile.
* Some stuff has been thrown around to different functions in an attempt to make the API function as small and concise as possible, improving legibility.