### PR TITLE
Rewrite with cleanup of melding API

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,29 +249,15 @@ async function ensureAuthorisation(store) {
   return organisationID;
 }
 
-async function jsonLdToStore(jsonLdObect) {
-  const requestNQuads = await jsonld.default.toRDF(jsonLdObect, {
-    format: 'application/n-quads',
-  });
-  const parser = new N3.Parser({ format: 'application/n-quads' });
-  const requestRdfjsTriples = parser.parse(requestNQuads);
+async function jsonLdToStore(jsonLdObject) {
+  const requestQuads = await jsonld.default.toRDF(jsonLdObject, {});
   const store = new N3.Store();
-  store.addQuads(requestRdfjsTriples);
+  store.addQuads(requestQuads);
   return store;
 }
 
 async function storeToJsonLd(store, context, frame) {
-  const writer = new N3.Writer({ format: 'application/n-quads' });
-  store.forEach((quad) => writer.addQuad(quad));
-  const ttl = await new Promise((resolve, reject) => {
-    writer.end((error, result) => {
-      if (error) reject(error);
-      else resolve(result);
-    });
-  });
-  const jsonld1 = await jsonld.default.fromRDF(ttl, {
-    format: 'application/n-quads',
-  });
+  const jsonld1 = await jsonld.default.fromRDF([...store], {});
   const framed = await jsonld.default.frame(jsonld1, frame);
   const compacted = await jsonld.default.compact(framed, context);
   return compacted;

--- a/app.js
+++ b/app.js
@@ -52,16 +52,6 @@ app.post('/melding', async function (req, res) {
 
     const submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationID);
 
-    // check if the resource has already been submitted
-    if (await isSubmitted(submittedResource, submissionGraph)) {
-      res.status(409).send({
-        errors: [{
-          title: `The given submittedResource <${submittedResource}> has already been submitted.`
-        }]
-      }).end();
-      return;
-    }
-
     // process the new auto-submission
     const { submissionUri, jobUri } = await storeSubmission(triples, submissionGraph, authenticationConfiguration);
     res.status(201).send({submission: submissionUri, job: jobUri}).end();

--- a/app.js
+++ b/app.js
@@ -47,13 +47,13 @@ app.post('/melding', async function (req, res) {
     // authenticate vendor
     const organisationID = await ensureAuthorisation(store);
 
-    // check if the resource has already been submitted
-    await ensureNotSubmitted(submittedResource);
-
     const submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationID);
 
+    // check if the resource has already been submitted
+    await ensureNotSubmitted(submittedResource, submissionGraph);
+
     // process the new auto-submission
-    const { submissionUri, jobUri } = await storeSubmission(triples, submissionGraph, authenticationConfiguration);
+    const { submissionUri, jobUri } = await storeSubmission(store, submissionGraph, authenticationConfiguration);
     res.status(201).send({submission: submissionUri, job: jobUri}).end();
   } catch (e) {
     console.error(e.message);
@@ -221,8 +221,8 @@ function ensureValidRegisterProperties(object) {
     );
 }
 
-async function ensureNotSubmitted(submittedResource) {
-  if (await isSubmitted(submittedResource))
+async function ensureNotSubmitted(submittedResource, submissionGraph) {
+  if (await isSubmitted(submittedResource, submissionGraph))
     throw new Error(
       `The given submittedResource <${submittedResource}> has already been submitted.`
     );

--- a/app.js
+++ b/app.js
@@ -23,101 +23,65 @@ app.use(errorHandler);
 app.use(bodyParser.json({type: 'application/ld+json'}));
 app.use(bodyParser.json());
 
-app.post('/melding', async function (req, res, next) {
-  const validContentType = /application\/(ld\+)?json/.test(req.get('content-type'));
-  if (!validContentType) {
-    res.status(400).send({errors: [{title: "invalid content-type only application/json or application/ld+json are accepted"}]}).end();
-  }
+app.post('/melding', async function (req, res) {
   try {
-    if (req.body instanceof Array) {
-      res.status(400).send({errors: [{title: "invalid json payload, expected an object but found array"}]}).end();
-    } else {
-      const body = req.body;
-      console.log("Incoming request on /melding");
-      //console.debug(body);
+    ensureValidContentType(req.get('content-type'));
+    ensureValidDataType(req.body);
+    // enrich the body with minimum required json LD properties
+    const enrichedBody = await enrichBodyForRegister(req.body);
+    // extracted the minimal required triples
+    const store = await jsonLdToStore(enrichedBody);
+    //const triples = await jsonld.default.toRDF(enrichedBody, {});
 
-      // enrich the body with minimum required json LD properties
-      await enrichBodyForRegister(body);
-      // extracted the minimal required triples
-      const triples = await jsonld.default.toRDF(body, {});
+    const extracted = extractInfoFromTriplesForRegister(store);
 
-      const extracted = extractInfoFromTriplesForRegister(triples);
+    // check if the minimal required payload is available
+    ensureMinimalRegisterPayload(extracted);
 
-      // check if the minimal required payload is available
-      for (let prop in extracted) {
-        if (!extracted[prop] && prop != 'authenticationConfiguration') { //TODO: if required vs optional fields grow, this will need to be better
-          console.log(`WARNING: received an invalid JSON-LD payload! Could not extract ${prop}`);
-          console.debug(body);
-          res.status(400).send({
-            errors: [{
-              title: `Invalid JSON-LD payload: property ${prop.toLocaleUpperCase()} is missing or invalid.`,
-              extractedTriples: triples
-            }]
-          }).end();
-          return;
-        }
-      }
+    // check if the extracted properties are valid
+    ensureValidRegisterProperties(extracted);
 
-      // check if the extracted properties are valid
-      const {isValid, errors} = validateExtractedInfo(extracted);
-      if (!isValid) {
-        res.status(400).send({errors}).end();
-        return;
-      }
+    const { submittedResource, authenticationConfiguration } = extracted;
 
-      const { key, vendor, organisation, submittedResource, authenticationConfiguration } = extracted;
+    // authenticate vendor
+    const organisationID = await ensureAuthorisation(store);
 
-      // authenticate vendor
-      const organisationID = await verifyKeyAndOrganisation(vendor, key, organisation);
-      if (!organisationID) {
-        const detail = JSON.stringify(cleanseRequestBody(req.body), undefined, 2);
-        sendErrorAlert({
-          message: `Authentication failed, vendor does not have access to the organization or doesn't exist.` ,
-          detail,
-          reference: vendor
-        });
-        res.status(401).send({
-          errors: [{
-            title: "Authentication failed, you do not have access to this resource. " +
-              "If this should not be the case, please contact us at digitaalABB@vlaanderen.be for login credentials."
-          }]
-        }).end();
-        return;
-      }
+    // check if the resource has already been submitted
+    await ensureNotSubmitted(submittedResource);
 
-      // check if the resource has already been submitted
-      if (await isSubmitted(submittedResource)) {
-        res.status(409).send({
-          errors: [{
-            title: `The given submittedResource <${submittedResource}> has already been submitted.`
-          }]
-        }).end();
-        return;
-      }
-
-      // process the new auto-submission
-      const submissionGraph = `http://mu.semte.ch/graphs/organizations/${organisationID}/LoketLB-toezichtGebruiker`;
-      const { submissionUri, jobUri } = await storeSubmission(triples, submissionGraph, submissionGraph, authenticationConfiguration);
-      res.status(201).send({submission: submissionUri, job: jobUri}).end();
-    }
+    // process the new auto-submission
+    const submissionGraph = `http://mu.semte.ch/graphs/organizations/${organisationID}/LoketLB-toezichtGebruiker`;
+    const { submissionUri, jobUri } = await storeSubmission(
+      store,
+      submissionGraph,
+      submissionGraph,
+      authenticationConfiguration
+    );
+    res.status(201).send({ submission: submissionUri, job: jobUri }).end();
   } catch (e) {
     console.error(e.message);
     if (!e.alreadyStoredError) {
-      const detail = JSON.stringify( {
-        err: e.message,
-        req: cleanseRequestBody(req.body)
-      }, undefined, 2);
+      const detail = JSON.stringify(
+        {
+          err: e.message,
+          req: cleanseRequestBody(req.body),
+        },
+        undefined,
+        2
+      );
       sendErrorAlert({
-        message: 'Something unexpected went wrong while processing an auto-submission request.',
+        message:
+          'Something unexpected went wrong while processing an auto-submission request.',
         detail,
+        reference: e.reference,
       });
     }
-    res.status(400).send({
-      errors: [{
-        title: 'Something unexpected happened while processing the auto-submission request. ' +
-          'If this keeps occurring, please contact us at digitaalABB@vlaanderen.be.'
-      }]
-    }).end();
+    res
+      .status(500)
+      .send(
+        `An error happened while processing the auto-submission request. If this keeps occurring for no good reason, please contact us at digitaalABB@vlaanderen.be. Please consult the technical error below.\n${e.message}`
+      )
+      .end();
   }
 });
 
@@ -225,6 +189,39 @@ function ensureValidContentType(contentType) {
     );
 }
 
+function ensureValidDataType(body) {
+  if (body instanceof Array)
+    throw new Error(
+      'Invalid JSON payload, expected an object but found array.'
+    );
+}
+
+function ensureMinimalRegisterPayload(object) {
+  for (const prop in object)
+    if (!object[prop] && prop != 'authenticationConfiguration')
+      throw new Error(
+        `Invalid JSON-LD payload: property "${prop}" is missing or invalid.`
+      );
+}
+
+function ensureValidRegisterProperties(object) {
+  const { isValid, errors } = validateExtractedInfo(object);
+  if (!isValid)
+    throw new Error(
+      `Some given properties are invalid:\n${errors
+        .map((e) => e.message)
+        .join('\n')}
+      `
+    );
+}
+
+async function ensureNotSubmitted(submittedResource) {
+  if (await isSubmitted(submittedResource))
+    throw new Error(
+      `The given submittedResource <${submittedResource}> has already been submitted.`
+    );
+}
+
 async function ensureAuthorisation(store) {
   const authentication = extractAuthentication(store);
   if (
@@ -242,10 +239,14 @@ async function ensureAuthorisation(store) {
     authentication.key,
     authentication.organisation
   );
-  if (!organisationID)
-    throw new Error(
-      'Authentication failed, vendor does not have access to the organization or does not exist.'
+  if (!organisationID) {
+    const error = new Error(
+      'Authentication failed, vendor does not have access to the organization or does not exist. If this should not be the case, please contact us at digitaalABB@vlaanderen.be for login credentials.'
     );
+    error.reference = authentication.vendor;
+    throw error;
+  }
+  return organisationID;
 }
 
 async function jsonLdToStore(jsonLdObect) {

--- a/jsonld-input.js
+++ b/jsonld-input.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { uuid } from 'mu';
 import * as env from './env.js';
 import { SubmissionRegistrationContext } from './SubmissionRegistrationContext.js';
@@ -51,32 +50,30 @@ export async function enrichBodyForStatus(body) {
   return body;
 }
 
-export function extractInfoFromTriplesForRegister(triples) {
-  const key = _.get(triples.find(
-    (triple) => triple.predicate.value === 'http://mu.semte.ch/vocabularies/account/key'), "object.value");
-
-  const vendor = _.get(triples.find(
-    (triple) => triple.predicate.value === 'http://purl.org/pav/providedBy'), "object.value");
-
-  const organisation = _.get(triples.find(
-    (triple) => triple.predicate.value === 'http://purl.org/pav/createdBy'), "object.value");
-
-  const submittedResource = _.get(triples.find(
-    (triple) => triple.predicate.value === 'http://purl.org/dc/terms/subject'), "object.value");
-
-  const status = _.get(triples.find(
-    (triple) => triple.predicate.value === 'http://www.w3.org/ns/adms#status'), "object.value");
-
-  const authenticationConfiguration = _.get(triples.find(
-    (triple) => triple.predicate.value === 'http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration'), "object.value");
-
+export function extractInfoFromTriplesForRegister(store) {
+  const locationHrefs = store.getObjects(
+    undefined,
+    namedNode('http://www.w3.org/ns/prov#atLocation')
+  );
+  const submittedResources = store.getObjects(
+    undefined,
+    namedNode('http://purl.org/dc/terms/subject')
+  );
+  const statuses = store.getObjects(
+    undefined,
+    namedNode('http://www.w3.org/ns/adms#status')
+  );
+  const authenticationConfigurations = store.getObjects(
+    undefined,
+    namedNode(
+      'http://lblod.data.gift/vocabularies/security/targetAuthenticationConfiguration'
+    )
+  );
   return {
-    key,
-    vendor,
-    organisation,
-    submittedResource,
-    status,
-    authenticationConfiguration
+    submittedResource: submittedResources[0]?.value,
+    status: statuses[0]?.value,
+    authenticationConfiguration: authenticationConfigurations[0]?.value,
+    href: locationHrefs[0]?.value,
   };
 }
 
@@ -101,10 +98,10 @@ export function extractAuthentication(store) {
 }
 
 export function validateExtractedInfo(extracted) {
-  const {status} = extracted;
+  const { status } = extracted;
   const errors = [];
   if (status !== env.CONCEPT_STATUS && status !== env.SUBMITTABLE_STATUS)
-    errors.push({title: `property status is not valid.`});
+    errors.push({ message: 'Property status is not valid.' });
 
-  return {isValid: errors.length === 0, errors};
+  return { isValid: errors.length === 0, errors };
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "async-await-mutex-lock": "^1.0.9",
     "express-rate-limit": "^6.6.0",
     "jsonld": "^8.1.0",
-    "lodash": "^4.17.15",
     "n3": "^1.16.2",
     "sparqljson-parse": "^2.1.1"
   },

--- a/support.js
+++ b/support.js
@@ -74,7 +74,7 @@ async function storeToTurtle(store) {
   return ttl;
 }
 
-async function storeSubmission(triples, submissionGraph, authenticationConfiguration) {
+async function storeSubmission(store, submissionGraph, authenticationConfiguration) {
   let newAuthConf = {};
   const meldingUri = extractMeldingUri(store);
   const { jobUri, automaticSubmissionTaskUri, } = await jobsAndTasks.startJob(submissionGraph, meldingUri);


### PR DESCRIPTION
This PR just cleans up the function responsible for dealing with incoming requests for registering a submission. This function was long and difficult to read. Moved a lot of code into separate reusable functions that throw errors when there is a problem. Simplified error handling into a single try-catch. Also used RDFJS triples and a store to carry around triples instead of a non documented format (the result of `jsonld.toRDF`).