### PR TITLE
Only insert in one graph

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.4
+FROM semtech/mu-javascript-template:1.6.0
 LABEL maintainer=info@redpencil

--- a/app.js
+++ b/app.js
@@ -76,8 +76,10 @@ app.post('/melding', async function (req, res, next) {
         return;
       }
 
+      const submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationID);
+
       // check if the resource has already been submitted
-      if (await isSubmitted(submittedResource)) {
+      if (await isSubmitted(submittedResource, submissionGraph)) {
         res.status(409).send({
           errors: [{
             title: `The given submittedResource <${submittedResource}> has already been submitted.`
@@ -87,8 +89,7 @@ app.post('/melding', async function (req, res, next) {
       }
 
       // process the new auto-submission
-      const submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationID);
-      const uri = await storeSubmission(triples, submissionGraph, submissionGraph, authenticationConfiguration);
+      const uri = await storeSubmission(triples, submissionGraph, authenticationConfiguration);
       res.status(201).send({uri}).end();
     }
   } catch (e) {

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import { remoteDataObjectStatusChange } from './downloadTaskManagement.js';
 import * as env from './env.js';
 import { getTaskInfoFromRemoteDataObject, downloadTaskUpdate } from './downloadTaskManagement.js';
 import { Lock } from 'async-await-mutex-lock';
+import * as config from './config';
 
 app.use(errorHandler);
 // support both jsonld and json content-type
@@ -86,7 +87,7 @@ app.post('/melding', async function (req, res, next) {
       }
 
       // process the new auto-submission
-      const submissionGraph = `http://mu.semte.ch/graphs/organizations/${organisationID}/LoketLB-toezichtGebruiker`;
+      const submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationID);
       const uri = await storeSubmission(triples, submissionGraph, submissionGraph, authenticationConfiguration);
       res.status(201).send({uri}).end();
     }

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+import * as env from 'env-var';
+
+export const GRAPH_TEMPLATE = env.get('GRAPH_TEMPLATE')
+  .example('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .default('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .asUrlString();
+
+(function checkEnvVars() {
+  if (!/~ORGANIZATION_ID~/g.test(GRAPH_TEMPLATE))
+    throw new Error(`The GRAPH_TEMPLATE environment variable "${GRAPH_TEMPLATE}" does not contain a "~ORGANIZATION_ID~".`);
+})();

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Microservice providing an API for external parties to process inzendingen voor toezicht.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",
+    "async-await-mutex-lock": "^1.0.9",
+    "env-var": "^7.3.0",
     "jsonld": "^1.7.0",
-    "n3": "^1.2.0",
     "lodash": "^4.17.15",
-    "async-await-mutex-lock": "^1.0.9"
+    "n3": "^1.2.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/support.js
+++ b/support.js
@@ -58,7 +58,7 @@ async function triplesToTurtle(triples) {
   return promise;
 }
 
-async function storeSubmission(triples, submissionGraph, fileGraph, authenticationConfiguration) {
+async function storeSubmission(triples, submissionGraph, authenticationConfiguration) {
   let newAuthConf = {};
   const meldingUri = extractMeldingUri(triples);
   const { jobUri, automaticSubmissionTaskUri, } = await jobsAndTasks.startJob(submissionGraph, meldingUri);
@@ -99,12 +99,12 @@ async function storeSubmission(triples, submissionGraph, fileGraph, authenticati
     // E.g. after import-submission we're quite sure. But what if something goes wrong before that, or a download just takes longer.
     // The highly aync process makes it complicated
     // Note: probably some clean up background job might be needed. Needs perhaps a bit of better thinking
-    newAuthConf = await attachClonedAuthenticationConfiguraton(remoteDataUri, meldingUri, fileGraph);
+    newAuthConf = await attachClonedAuthenticationConfiguraton(remoteDataUri, meldingUri, submissionGraph);
 
     await update(`
       ${env.PREFIXES}
       INSERT DATA {
-        GRAPH ${sparqlEscapeUri(fileGraph)} {
+        GRAPH ${sparqlEscapeUri(submissionGraph)} {
             ${sparqlEscapeUri(remoteDataUri)} a nfo:RemoteDataObject, nfo:FileDataObject;
                                               rpioHttp:requestHeader <http://data.lblod.info/request-headers/accept/text/html>;
                                               mu:uuid ${sparqlEscapeString(remoteDataId)};
@@ -159,11 +159,11 @@ async function storeSubmission(triples, submissionGraph, fileGraph, authenticati
   }
 }
 
-async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submissionUri, remoteObjectGraph) {
+async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submissionUri, submissionGraph) {
   const getInfoQuery = `
     ${env.PREFIXES}
     SELECT DISTINCT ?graph ?secType ?authenticationConfiguration WHERE {
-     GRAPH ?graph {
+     GRAPH ${sparqlEscapeUri(submissionGraph)} {
        ${sparqlEscapeUri(submissionUri)} dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration.
        ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?secType .
      }
@@ -183,12 +183,8 @@ async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submi
     cloneQuery = `
       ${env.PREFIXES}
       INSERT {
-        GRAPH ${sparqlEscapeUri(remoteObjectGraph)} {
-          ${sparqlEscapeUri(remoteDataObjectUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(
-        newAuthConf)} .
-        }
-
-        GRAPH ${sparqlEscapeUri(authData.graph)} {
+        GRAPH ${sparqlEscapeUri(submissionGraph)} {
+          ${sparqlEscapeUri(remoteDataObjectUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConf)} .
           ${sparqlEscapeUri(newAuthConf)} dgftSec:secrets ${sparqlEscapeUri(newCreds)} .
           ${sparqlEscapeUri(newCreds)} meb:username ?user ;
             muAccount:password ?pass .
@@ -198,24 +194,21 @@ async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submi
         }
       }
       WHERE {
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
-        ?srcConfg ?srcConfP ?srcConfO.
+        GRAPH ${sparqlEscapeUri(submissionGraph)} {
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+          ?srcConfg ?srcConfP ?srcConfO.
 
-       ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
-       ?srcSecrets  meb:username ?user ;
-         muAccount:password ?pass .
-     }
-   `;
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+          ?srcSecrets  meb:username ?user ;
+            muAccount:password ?pass .
+        }
+     }`;
   } else if (authData.secType == env.OAUTH2) {
     cloneQuery = `
       ${env.PREFIXES}
       INSERT {
-        GRAPH ${sparqlEscapeUri(remoteObjectGraph)} {
-          ${sparqlEscapeUri(remoteDataObjectUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(
-        newAuthConf)} .
-        }
-
-        GRAPH ${sparqlEscapeUri(authData.graph)} {
+        GRAPH ${sparqlEscapeUri(submissionGraph)} {
+          ${sparqlEscapeUri(remoteDataObjectUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConf)} .
           ${sparqlEscapeUri(newAuthConf)} dgftSec:secrets ${sparqlEscapeUri(newCreds)} .
           ${sparqlEscapeUri(newCreds)} dgftOauth:clientId ?clientId ;
             dgftOauth:clientSecret ?clientSecret .
@@ -225,14 +218,15 @@ async function attachClonedAuthenticationConfiguraton(remoteDataObjectUri, submi
         }
       }
       WHERE {
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
-        ?srcConfg ?srcConfP ?srcConfO.
+        GRAPH ${sparqlEscapeUri(submissionGraph)} {
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+          ?srcConfg ?srcConfP ?srcConfO.
 
-       ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
-       ?srcSecrets  dgftOauth:clientId ?clientId ;
-         dgftOauth:clientSecret ?clientSecret .
-     }
-   `;
+          ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+          ?srcSecrets  dgftOauth:clientId ?clientId ;
+            dgftOauth:clientSecret ?clientSecret .
+        }
+     }`;
   } else {
     throw `Unsupported Security type ${authData.secType}`;
   }

--- a/support.js
+++ b/support.js
@@ -4,13 +4,15 @@ import { Writer } from 'n3';
 import * as env from './env.js';
 import * as jobsAndTasks from './jobAndTaskManagement.js';
 
-async function isSubmitted(resource) {
+async function isSubmitted(resource, submissionGraph) {
   const result = await query(`
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
       SELECT (COUNT(*) as ?count)
       WHERE {
+        GRAPH ${sparqlEscapeUri(submissionGraph)} {
           ${sparqlEscapeUri(resource)} ?p ?o .
+        }
       }
     `);
 


### PR DESCRIPTION
In order to improve data security, the services in the automatic submission flow should only insert data in one specific controlled graph.

This fixes issues related to data spreading in graphs that should not contain that data. More specific for the vendor-data-distribution-service.

This PR includes a configuration file where the graph template is loaded from environment variables, but with sensible defaults so that nothing special should be done in most cases. The code is adapted to always compute the graph from the template in combination with the organisation ID before inserting into the triplestore.