### PR TITLE
Bump version of template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.4
+FROM semtech/mu-javascript-template:1.6.0
 LABEL maintainer=info@redpencil


### PR DESCRIPTION
Installing the package `env-var` requires an update to the JavaScript template version 1.6.0.