### PR TITLE
Fix: download status failure missing prefix

### DIFF
--- a/env.js
+++ b/env.js
@@ -56,6 +56,7 @@ export const PREFIX_TABLE = {
   tasko:        'http://lblod.data.gift/id/jobs/concept/TaskOperation/',
   jobo:         'http://lblod.data.gift/id/jobs/concept/JobOperation/',
   hrvst:        'http://lblod.data.gift/vocabularies/harvesting/',
+  oslc:         'http://open-services.net/ns/core#',
 };
 
 export const PREFIXES = (() => {


### PR DESCRIPTION
When the download fails, this service stores the error message to the triplestore, but there was as "oslc" prefix missing that would cause the query to fail. This would leave the task(s) and job to "ongoing" indefinitely.