### PR TITLE
Restore error codes and response

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,26 @@ Content-Type: application/json # or application/ld+json
 Getting the status can be done in the same context as registering a submission,
 but supply a submission URI instead. Look at some examples below.
 
-### Responses
+### Succesful response
+
+When the submission has been successfully sent in, you get the following response:
+
+```
+201 Created
+{
+  "uri": "http://data.lblod.info/submissions/e5725210-527b-11ee-bd48-c53e584duaa8",
+  "submission": "http://data.lblod.info/submissions/e5725210-527b-11ee-bd48-c53e584duaa8",
+  "job": "http://data.lblod.info/id/automatic-submission-job/e58a4fd0-522b-11ee-bd48-c56e584deaa8"
+}
+```
+
+The `uri` and `submission` properties are identical. The `uri` is there for
+backwards compatibility with an old version of this service. The `submission`
+and `job` properties contain the URIs for the newly created submission and the
+associated processing job respectively. These can be used in the [Vendor SPARQL
+API](https://lblod.github.io/pages-vendors/#/docs/vendor-sparql-api).
+
+### Error responses
 
 The following responses can be returned by this service. Error messages are
 displayed next to the HTTP response code here, but in the actual response, the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # automatic-submission-service
 
-Microservice providing an API for external parties to automatically process a submission.
+Microservice providing an API for external parties to automatically process a
+submission.
 
 ## Getting started
 
@@ -10,7 +11,7 @@ Add the service to your `docker-compose.yml`:
 
 ```yaml
 automatic-submission:
-  image: lblod/automatic-submission-service
+  image: lblod/automatic-submission-service:1.3.0
 ```
 
 Configure the dispatcher by adding the following rule:
@@ -25,7 +26,8 @@ end
 
 ### Authorize an agent to submit on behalf of an organization
 
-To allow an organization to submit a publication on behalf of another organization, add a resource similar to the example below:
+To allow an organization to submit a publication on behalf of another
+organization, add a resource similar to the example below:
 
 ```sparql
 PREFIX muAccount: 	<http://mu.semte.ch/vocabularies/account/>
@@ -38,7 +40,8 @@ INSERT DATA {
     <http://example.com/vendor/d3c9e5e5-d50c-46c9-8f09-6af76712c277>
       a foaf:Agent, ext:Vendor ;
       muAccount:key "my-super-secret-key";
-      muAccount:canActOnBehalfOf <http://data.lblod.info/id/bestuurseenheden/d64157ef-bde2-4814-b77a-2d43ce90d>;
+      muAccount:canActOnBehalfOf
+        <http://data.lblod.info/id/bestuurseenheden/d64157ef-bde2-4814-b77a-2d43ce90d>;
       foaf:name "Test vendor";
       mu:uuid "d3c9e5e5-d50c-46c9-8f09-6af76712c277".
   }
@@ -52,18 +55,28 @@ INSERT DATA {
 To register a new resource as a submission:
 
 ```
-POST /melding # Content-Type: application/json or application/ld+json
+POST /melding
+Content-Type: application/json # or application/ld+json
 ```
 
-Use the JSON-LD context as described in [Meldingsplicht API](https://lblod.github.io/pages-vendors/#/docs/submission-api) for how to structure the body.
+Use the JSON-LD context as described in [Meldingsplicht
+API](https://lblod.github.io/pages-vendors/#/docs/submission-api) for how to
+structure the body.
 
-To fetch the status of the procesing of the resource:
+**Note: refer to the documentation on the [Vendor SPARQL
+API](https://lblod.github.io/pages-vendors/#/docs/vendor-sparql-api). That is
+the supported way to get status information. Alternatively, you could also use
+the following.**
+
+To fetch the status of the processing of the resource:
 
 ```
-POST /status  # Content-Type: application/json or application/ld+json
+POST /status
+Content-Type: application/json # or application/ld+json
 ```
 
-Getting the status can be done in the same context as registering a submission, but supply a submission URI instead. Look at some examples below.
+Getting the status can be done in the same context as registering a submission,
+but supply a submission URI instead. Look at some examples below.
 
 #### Examples
 
@@ -150,9 +163,11 @@ Getting the status can be done in the same context as registering a submission, 
 }
 ```
 
-#### Submission with minimal body *(not recommended)*
+#### Submission with minimal body
 
-Due to the implementation of this service, the context and some other properties are always attached to the JSON(-LD) body before processing. This means you could get away with a very minimal body such as the following:
+Due to the implementation of this service, the context and some other
+properties are always attached to the JSON(-LD) body before processing. This
+means you could get away with a very minimal body such as the following:
 
 ```json
 {
@@ -168,7 +183,8 @@ Due to the implementation of this service, the context and some other properties
 
 #### Status request with minimal body *(not recommended)*
 
-The same as the previous example applies when it comes to asking for the status of the submission:
+The same as the previous example applies when it comes to asking for the status
+of the submission:
 
 ```json
 {
@@ -183,9 +199,13 @@ The same as the previous example applies when it comes to asking for the status 
 
 ### Authorization and security
 
-Submissions can only be submitted by known organizations using the API key they received. Organizations can only submit a publication on behalf of another organization if they have the permission to do so.
+Submissions can only be submitted by known organizations using the API key they
+received. Organizations can only submit a publication on behalf of another
+organization if they have the permission to do so.
 
-The service verifies the API key and permissions in the graph `http://mu.semte.ch/graphs/automatic-submission`. The organization the agents acts on behalf of should have a `mu:uuid`.
+The service verifies the API key and permissions in the graph
+`http://mu.semte.ch/graphs/automatic-submission`. The organization the agents
+acts on behalf of should have a `mu:uuid`.
 
 A second layer of authentication can be configured
 
@@ -244,7 +264,8 @@ A second layer of authentication can be configured
 
 #### Automatic submission task
 
-Upon receipt of the submission, the service will create an automatic submission job for the whole flow and a related task for the work in this services.
+Upon receipt of the submission, the service will create an automatic submission
+job for the whole flow and a related task for the work in this services.
 
 ##### Class
 
@@ -252,23 +273,41 @@ Upon receipt of the submission, the service will create an automatic submission 
 
 ##### Properties
 
-The model is specified in the [README of the job-controller-service](https://github.com/lblod/job-controller-service#task).
+The model is specified in the [README of the
+job-controller-service](https://github.com/lblod/job-controller-service#task).
 
 #### Automatic submission task statuses
 
-Once the automatic submission process starts, the status of the automatic submission task is updated to `http://redpencil.data.gift/id/concept/JobStatus/busy`.
+Once the automatic submission process starts, the status of the automatic
+submission task is updated to
+`http://redpencil.data.gift/id/concept/JobStatus/busy`.
 
-On successful completion, the status of the automatic submission task is updated to `http://redpencil.data.gift/id/concept/JobStatus/success`. The resultsContainer of the task wil contain a harvesting collection that refers to the remote data object for the HTML page containing the RDFa for the submission.
+On successful completion, the status of the automatic submission task is
+updated to `http://redpencil.data.gift/id/concept/JobStatus/success`. The
+resultsContainer of the task wil contain a harvesting collection that refers to
+the remote data object for the HTML page containing the RDFa for the
+submission.
 
-On failure, the status is updated to `http://redpencil.data.gift/id/concept/JobStatus/failed`. If possible, an error is written to the database and the error is linked to this failed task.
+On failure, the status is updated to
+`http://redpencil.data.gift/id/concept/JobStatus/failed`. If possible, an error
+is written to the database and the error is linked to this failed task.
 
 #### Download-url-service task
 
-In addition to a Job and Task for the automatic submission service, this service will also manage the download process from the download-url-service. The download-url-service is a reusable component that could not (yet) be adapted to integrate with the jobs-controller-service's model, so that service needs to be managed here too. To do this, some rules in the delta-notifier are needed and there is a extra API entry specifically for managing download statuses. This process will also create tasks as describe by the model referenced above. The jobs-controller-service needs to pick up after the download-url-service's task has been successful.
+In addition to a Job and Task for the automatic submission service, this
+service will also manage the download process from the download-url-service.
+The download-url-service is a reusable component that could not (yet) be
+adapted to integrate with the jobs-controller-service's model, so that service
+needs to be managed here too. To do this, some rules in the delta-notifier are
+needed and there is a extra API entry specifically for managing download
+statuses. This process will also create tasks as describe by the model
+referenced above. The jobs-controller-service needs to pick up after the
+download-url-service's task has been successful.
 
 #### Submission
 
-Submission to be processed automatically. The properties of the submission are retrieved from the JSON-LD body of the request.
+Submission to be processed automatically. The properties of the submission are
+retrieved from the JSON-LD body of the request.
 
 ##### Class
 
@@ -276,7 +315,11 @@ Submission to be processed automatically. The properties of the submission are r
 
 ##### Properties
 
-For a full list of properties of a submission, we refer to the [automatic submission documentation](https://lblod.github.io/pages-vendors/#/docs/submission-annotations). In addition to the properties, the automatic submission services enriches the submission with the following properties:
+For a full list of properties of a submission, we refer to the [automatic
+submission
+documentation](https://lblod.github.io/pages-vendors/#/docs/submission-annotations).
+In addition to the properties, the automatic submission services enriches the
+submission with the following properties:
 
 | Name              | Predicate     | Range                  | Definition                                     |
 |-------------------|---------------|------------------------|------------------------------------------------|
@@ -285,7 +328,9 @@ For a full list of properties of a submission, we refer to the [automatic submis
 
 #### Remote data object
 
-Upon receipt of the submission, the service will create a remote data object for the submitted publication URL which will be downloaded by the [download-url-service](https://github.com/lblod/download-url-service).
+Upon receipt of the submission, the service will create a remote data object
+for the submitted publication URL which will be downloaded by the
+[download-url-service](https://github.com/lblod/download-url-service).
 
 ##### Class
 
@@ -293,11 +338,18 @@ Upon receipt of the submission, the service will create a remote data object for
 
 ##### Properties
 
-The model of the remote data object is described in the [README of the download-url-service](https://github.com/lblod/download-url-service).
+The model of the remote data object is described in the [README of the
+download-url-service](https://github.com/lblod/download-url-service).
 
 #### Submitted resource
 
-Document that is the subject of the submission. The properties of the submitted resource are harvested from the publication URL by the [import-submission-service](https://github.com/lblod/import-submission-service), [enrich-submission-service](https://github.com/lblod/enrich-submission-service) and [validate-submission-service](https://github.com/lblod/validate-submission-service) at a later stage in the automatic submission process.
+Document that is the subject of the submission. The properties of the submitted
+resource are harvested from the publication URL by the
+[import-submission-service](https://github.com/lblod/import-submission-service),
+[enrich-submission-service](https://github.com/lblod/enrich-submission-service)
+and
+[validate-submission-service](https://github.com/lblod/validate-submission-service)
+at a later stage in the automatic submission process.
 
 ##### Class
 
@@ -305,11 +357,14 @@ Document that is the subject of the submission. The properties of the submitted 
 
 ##### Properties
 
-For a full list of properties of a submitted resource, we refer to the [automatic submission documentation](https://lblod.github.io/pages-vendors/#/docs/submission-annotations).
+For a full list of properties of a submitted resource, we refer to the
+[automatic submission
+documentation](https://lblod.github.io/pages-vendors/#/docs/submission-annotations).
 
 ## Related services
 
-The following services are also involved in the automatic processing of a submission:
+The following services are also involved in the automatic processing of a
+submission:
 
 * [download-url-service](https://github.com/lblod/download-url-service)
 * [import-submission-service](https://github.com/lblod/import-submission-service)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,37 @@ Content-Type: application/json # or application/ld+json
 Getting the status can be done in the same context as registering a submission,
 but supply a submission URI instead. Look at some examples below.
 
+### Responses
+
+The following responses can be returned by this service. Error messages are
+displayed next to the HTTP response code here, but in the actual response, the
+message is inside a structure like: `{"errors": [{"title": "...message..."}]}`.
+
+* `400 Content-Type not valid, only application/json or application/ld+json are
+  accepted`: when the content type is not correct. This service only accepts
+  JSON and JSON-LD content.
+* `400 Invalid JSON payload, expected an object but found array.`: when the
+  content structure is incorrect. Use properly formatted JSON.
+* `400 Invalid JSON-LD payload: property "XXX" is missing or invalid.`:
+  property `XXX` cound not be found in the request, but is needed.
+* `400 Some given properties are invalid: XXX`: `XXX` is a list of error
+  messages describing the problem with the given properties.
+* `409 The given submittedResource <URI> has already been submitted.`: when the
+  service can already find a submission for this URI. If you really need to
+  resend this submission, the previous submission has to be deleted first,
+  which is only possible if it is in "concept" status. The submission can then
+  be resent.
+* `400 The authentication (or part of it) for this request is missing. Make
+  sure to supply publisher (with vendor URI and key) and organization
+  information to the request.`: you need to supply at least `organization:
+  "<URI>", publisher: { uri: "<URI>", key: "XXX" }` with the correct
+  credentials to be able to post a submission.
+* `401 Authentication failed, vendor does not have access to the organization
+  or does not exist. If this should not be the case, please contact us at
+  digitaalABB@vlaanderen.be for login credentials.`: this is when the given
+  credentials are incorrect or these credentials do not allow for sending a
+  submission in this organisation.
+
 #### Examples
 
 ##### Submission with inline context

--- a/app.js
+++ b/app.js
@@ -92,9 +92,10 @@ app.post('/melding', async function (req, res) {
       });
     }
     res
-      .status(500)
+      .status(e.errorCode || 500)
       .send(
-        `An error happened while processing the auto-submission request. If this keeps occurring for no good reason, please contact us at digitaalABB@vlaanderen.be. Please consult the technical error below.\n${e.message}`,
+        e.errorBody ||
+          `An error happened while processing the auto-submission request. If this keeps occurring for no good reason, please contact us at digitaalABB@vlaanderen.be. Please consult the technical error below.\n${e.message}`,
       )
       .end();
   }
@@ -221,43 +222,65 @@ app.post('/status', statusLimiter, async function (req, res) {
 ///////////////////////////////////////////////////////////////////////////////
 
 function ensureValidContentType(contentType) {
-  if (!/application\/(ld\+)?json/.test(contentType))
-    throw new Error(
+  if (!/application\/(ld\+)?json/.test(contentType)) {
+    const err = new Error(
       'Content-Type not valid, only application/json or application/ld+json are accepted',
     );
+    err.errorCode = 400;
+    err.errorBody = { errors: [{ title: err.message }] };
+    throw err;
+  }
 }
 
 function ensureValidDataType(body) {
-  if (body instanceof Array)
-    throw new Error(
+  if (body instanceof Array) {
+    const err = new Error(
       'Invalid JSON payload, expected an object but found array.',
     );
+    err.errorCode = 400;
+    err.errorBody = { errors: [{ title: err.message }] };
+    throw err;
+  }
 }
 
 function ensureMinimalRegisterPayload(object) {
   for (const prop in object)
-    if (!object[prop] && prop != 'authenticationConfiguration')
-      throw new Error(
+    if (!object[prop] && prop != 'authenticationConfiguration') {
+      const err = new Error(
         `Invalid JSON-LD payload: property "${prop}" is missing or invalid.`,
       );
+      err.errorCode = 400;
+      err.errorBody = {
+        errors: [{ title: err.message }],
+      };
+      throw err;
+    }
 }
 
 function ensureValidRegisterProperties(object) {
   const { isValid, errors } = validateExtractedInfo(object);
-  if (!isValid)
-    throw new Error(
+  if (!isValid) {
+    const err = new Error(
       `Some given properties are invalid:\n${errors
         .map((e) => e.message)
         .join('\n')}
-      `,
+        `,
     );
+    err.errorCode = 400;
+    err.errorBody = { errors };
+    throw err;
+  }
 }
 
 async function ensureNotSubmitted(submittedResource, submissionGraph) {
-  if (await isSubmitted(submittedResource, submissionGraph))
-    throw new Error(
+  if (await isSubmitted(submittedResource, submissionGraph)) {
+    const err = new Error(
       `The given submittedResource <${submittedResource}> has already been submitted.`,
     );
+    err.errorCode = 409;
+    err.errorBody = { errors: [{ title: err.message }] };
+    throw err;
+  }
 }
 
 async function ensureAuthorisation(store) {
@@ -268,10 +291,14 @@ async function ensureAuthorisation(store) {
       authentication.key &&
       authentication.organisation
     )
-  )
-    throw new Error(
+  ) {
+    const err = new Error(
       'The authentication (or part of it) for this request is missing. Make sure to supply publisher (with vendor URI and key) and organization information to the request.',
     );
+    err.errorCode = 400;
+    err.errorBody = { errors: [{ title: err.message }] };
+    throw err;
+  }
   const organisationID = await verifyKeyAndOrganisation(
     authentication.vendor,
     authentication.key,
@@ -281,6 +308,8 @@ async function ensureAuthorisation(store) {
     const error = new Error(
       'Authentication failed, vendor does not have access to the organization or does not exist. If this should not be the case, please contact us at digitaalABB@vlaanderen.be for login credentials.',
     );
+    error.errorCode = 401;
+    error.errorBody = { errors: [{ title: error.message }] };
     error.reference = authentication.vendor;
     throw error;
   }

--- a/app.js
+++ b/app.js
@@ -69,7 +69,10 @@ app.post('/melding', async function (req, res) {
       submissionGraph,
       authenticationConfiguration,
     );
-    res.status(201).send({ submission: submissionUri, job: jobUri }).end();
+    res
+      .status(201)
+      .send({ uri: submissionUri, submission: submissionUri, job: jobUri })
+      .end();
   } catch (e) {
     console.error(e.message);
     if (!e.alreadyStoredError) {

--- a/support.js
+++ b/support.js
@@ -377,8 +377,8 @@ export async function verifyKeyAndOrganisation(vendor, key, organisation) {
 
 export function cleanseRequestBody(body) {
   const cleansed = body;
-  delete cleansed.authentication;
-  delete cleansed.publisher.key;
+  if (cleansed?.authentication) delete cleansed.authentication;
+  if (cleansed?.publisher?.key) delete cleansed.publisher.key;
   return cleansed;
 }
 


### PR DESCRIPTION
This PR restores the previous way of returning error codes and also adds back the `uri` key (even if rather meaningless) to the response. Previous changes seem to have broken how the vendors worked with the API and this PR aims to restore that functionality.