### PR TITLE
Bug/improve validation already submitted

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ app.post('/melding', async function (req, res) {
     );
 
     // check if the resource has already been submitted
-    await ensureNotSubmitted(submittedResource, submissionGraph);
+    await ensureNotSubmitted(submittedResource);
 
     // process the new auto-submission
     const { submissionUri, jobUri } = await storeSubmission(
@@ -275,8 +275,8 @@ function ensureValidRegisterProperties(object) {
   }
 }
 
-async function ensureNotSubmitted(submittedResource, submissionGraph) {
-  if (await isSubmitted(submittedResource, submissionGraph)) {
+async function ensureNotSubmitted(submittedResource) {
+  if (await isSubmitted(submittedResource)) {
     const err = new Error(
       `The given submittedResource <${submittedResource}> has already been submitted.`,
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automatic-submission-service",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Microservice providing an API for external parties to process inzendingen voor toezicht.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.0",

--- a/support.js
+++ b/support.js
@@ -16,9 +16,7 @@ export async function isSubmitted(resource, submissionGraph) {
 
       SELECT (COUNT(*) as ?count)
       WHERE {
-        GRAPH ${sparqlEscapeUri(submissionGraph)} {
-          ${sparqlEscapeUri(resource)} ?p ?o .
-        }
+        ${sparqlEscapeUri(resource)} ?p ?o .
       }
     `);
   return parseInt(result.results.bindings[0].count.value) > 0;


### PR DESCRIPTION
Remove ?graph-constraint from ensureNotsubmitted.

We don't want any double submission on a submitted resource.

Fixes a bug where a 2 bestuurseenheden sent the same resource.
DL-6382